### PR TITLE
Play audio directly from HTTP response; update dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,7 @@
-(defproject facts/speech-synthesis "1.0.0"
+(defproject facts/speech-synthesis "1.0.1"
   :description "A library to speak text."
-  :dependencies [[org.clojure/clojure "1.3.0"]
-                 [clj-http "0.2.5"]
-                 [fs "1.0.0"]
+  :dependencies [[org.clojure/clojure "1.5.1"]
+                 [clj-http "1.0.1"]
                  [de.huxhorn.sulky/de.huxhorn.sulky.3rdparty.jlayer "1.0"]]
   :dev-dependencies [[swank-clojure "1.4.0-SNAPSHOT"]
                      [lein-clojars "0.6.0"]])

--- a/src/speech_synthesis/say.clj
+++ b/src/speech_synthesis/say.clj
@@ -1,8 +1,6 @@
 (ns speech-synthesis.say
-  (:require [clj-http.client :as client]
-            [fs.core :as fs]
-            [clojure.java.io :as io])
-  (:import (java.io File FileOutputStream)
+  (:require [clj-http.client :as client])
+  (:import (java.io File FileOutputStream ByteArrayInputStream)
            (javazoom.jl.player Player)))
 
 (defn say [response]
@@ -10,9 +8,6 @@
                         {:query-params {"ie" "UTF-8"
                                         "tl" "en"
                                         "q" response}
-                         :as :byte-array}))
-        file (fs/temp-file "say" ".mp3")]
-    (with-open [file (FileOutputStream. file)]
-      (.write file mp3))
-    (with-open [player (new Player (io/input-stream file))]
+                         :as :byte-array})) ]
+    (with-open [player (new Player (ByteArrayInputStream. mp3))]
       (.play player))))


### PR DESCRIPTION
Since we're already fetching it into memory as a byte array,
there's no need to write it to disk first
